### PR TITLE
Add Grafana workspace using Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+.*.lock.hcl

--- a/amg_workspace/aws-iam-policy.json
+++ b/amg_workspace/aws-iam-policy.json
@@ -1,0 +1,28 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "grafana:*",
+                "sso:DescribeRegisteredRegions",
+                "sso:CreateManagedApplicationInstance",
+                "sso:DeleteManagedApplicationInstance"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:ListInstanceProfilesForRole",
+                "iam:PassRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:ListRolePolicies"
+            ],
+            "Resource": "arn:aws:iam::${AWS-Account#}:role/tf-grafana-assume"
+        }
+    ]
+}

--- a/azure-pipelines-dashboard.yml
+++ b/azure-pipelines-dashboard.yml
@@ -87,36 +87,3 @@ stages:
           script: 'terraform apply -var region=$(region) -var access_key=$(access_key) -var secret_key=$(secret_key) --auto-approve -no-color'
           workingDirectory: '$(build.sourcesdirectory)/amg_workspace'
         displayName: "Terraform apply"
-      - task: PowerShell@2
-        inputs:  
-          targetType: 'inline'
-          script: 'terraform output -var region=$(region) -var access_key=$(access_key) -var secret_key=$(secret_key) --auto-approve -no-color'
-          workingDirectory: '$(build.sourcesdirectory)/amg_workspace'
-        displayName: "Terraform output"
-  # - stage: generate_api_key
-  #   displayName: Generate API Key
-  #   jobs:
-  #   - job: 
-  #     pool:
-  #       vmImage: ubuntu-latest
-  #     steps:
-  #     - task: PowerShell@2
-  #       displayName: 'Check and install AWS.Tools.Installer and AWS.Tools.Common modules'
-  #       inputs:
-  #         filePath: 'InstallAWSTools.ps1'
-  #     - task: PowerShell@2
-  #       displayName: 'Check commandline options for new key'
-  #       inputs:
-  #         targetType: 'inline'
-  #         script: |
-  #           New-MGRFWorkspaceApiKey
-  #       continueOnError: true
-  #     - task: PowerShell@2
-  #       displayName: 'Check commandline options for existing key'
-  #       inputs:
-  #         targetType: 'inline'
-  #         script: |
-  #           Remove-MGRFWorkspaceApiKey
-
-
-            


### PR DESCRIPTION
The changes in this PR create the Amazon Managed Grafana workspace using Azure DevOps pipelines. Also the [aws-iam-policy.json](https://github.com/kunduso/aws_managed_grafana_workspace_dashboard/blob/dev/add-dashboard/amg_workspace/aws-iam-policy.json) in the repo can be associated with a user provisioning the workspace since it has all the necessary permissions to manage this terraform stack